### PR TITLE
Add `shouldSendDeviceID` to iOS docs.

### DIFF
--- a/contents/docs/integrate/client/ios/index.mdx
+++ b/contents/docs/integrate/client/ios/index.mdx
@@ -204,6 +204,14 @@ configuration.capturePushNotifications = NO;
  * continueUserActivity and openURL methods on the posthog client.
  */
 configuration.captureDeepLinks = NO;
+
+/**
+ * Whether the posthog client should include the `$device_id` property when sending events.
+ * When enabled, `UIDevice`'s `identifierForVendor` property is used. Changing the value of
+ * of this property after initializing the client will have no effect.
+ * The default value is `YES`.
+ */
+configuration.shouldSendDeviceID = YES;
 ``` 
 
 ## Thank you


### PR DESCRIPTION
## Changes

Follows on from https://github.com/PostHog/posthog-ios/pull/21 by adding the setting to the docs for iOS.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)

**Note:** I haven't capitalized PostHog to match the other occurrences in the same section.